### PR TITLE
Updates debug to patch vulnerable ms package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "body-parser": "~1.14.0",
-    "debug": "~2.0.0",
+    "debug": "^2.2.0",
     "faye-websocket": "~0.7.2",
     "livereload-js": "^2.2.0",
     "parseurl": "~1.3.0",


### PR DESCRIPTION
The NSP (Node Security Project) command currently finds a vulnerability in mini-lr since it depends on the debug module which depends on a vulnerable version of the ms module (more details in https://nodesecurity.io/advisories/46). 

Running 
`nsp check`
outputs

```
(+) 1 vulnerabilities found
┌───────────────┬─────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                        │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ Name          │ ms                                                          │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ Installed     │ 0.6.2                                                       │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=0.7.0                                                     │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ Patched       │ >0.7.0                                                      │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ Path          │ mini-lr@0.1.8 > debug@2.0.0 > ms@0.6.2                      │
├───────────────┼─────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/46                       │
└───────────────┴─────────────────────────────────────────────────────────────┘
```

Updating debug fixes this
